### PR TITLE
Update node, fix deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ $ sudo apt full-upgrade -y
 ```
 
 ```shell
-$ curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash
+$ curl -sL https://deb.nodesource.com/setup_24.x | sudo -E bash
 $ sudo apt-get install -y nodejs
 ```
 

--- a/src/utils/multibase.js
+++ b/src/utils/multibase.js
@@ -22,7 +22,7 @@ class Multibase {
   async isRunning() {
     if (this.config.platform === 'linux') {
       let running = true;
-      const state = await this.exec('mbasectl', ['-i']);
+      const state = await this.exec('mbasectl -i');
       console.log('multibase state: ', state);
       for (const output of state.out) {
         if (output.includes('not running')) {
@@ -39,7 +39,7 @@ class Multibase {
       const running = await this.isRunning();
       if (!running) {
         console.log('Starting Buckeye Multibase SE...');
-        await this.exec('mbasectl', ['-s']);
+        await this.exec('mbasectl -s');
       }
     } else if (this.config.platform === 'win32') {
       console.log('Windows detected, starting Buckeye X-Manager');
@@ -54,7 +54,7 @@ class Multibase {
       const running = await this.isRunning();
       if (running) {
         console.log('Stopping Multibase SE...');
-        await this.exec('mbasectl', ['-k']);
+        await this.exec('mbasectl -k');
         console.log('Multibase SE stopped');
       }
     }


### PR DESCRIPTION
Some of our Base Stations were running Node 14, which is no longer supported. This PR updates the setup instructions to use to the current LTS release (Node 24.x) and addresses a [deprecation warning](https://nodejs.org/api/deprecations.html#dep0190-passing-args-to-nodechild_process-execfilespawn-with-shell-option-true).

I also am manually updating Node on all active base stations. 